### PR TITLE
Switched DNS to public IPv6 adresses

### DIFF
--- a/ns1.yml
+++ b/ns1.yml
@@ -49,8 +49,8 @@
     - dns_authoritative_external:
       - domain: "n.ffh.zone"
         zonefile: "n.ffh.zone.zone"
-      - domain: "8.0.0.0.e.e.f.f.a.c.d.f.ip6.arpa"
-        zonefile: "8.0.0.0.e.e.f.f.a.c.d.f.ip6.arpa.zone"
+      - domain: "7.0.0.0.f.f.0.0.0.9.7.0.2.0.a.2.ip6.arpa"
+        zonefile: "7.0.0.0.f.f.0.0.0.9.7.0.2.0.a.2.ip6.arpa.zone"
       - domain: "ffh"
         zonefile: "ffh.zone"
       - domain: "hannover.freifunk.net"
@@ -59,8 +59,8 @@
 
     - dns_zonenodes_toplevel: "ffh.zone."
     - dns_zonenodes_nodedomain: "n.ffh.zone"
-    - dns_zonenodes_rdnsdomain: "8.0.0.0.e.e.f.f.a.c.d.f.ip6.arpa"
-    - dns_zonenodes_matchIP: "/^fdca/"
+    - dns_zonenodes_rdnsdomain: "7.0.0.0.f.f.0.0.0.9.7.0.2.0.a.2.ip6.arpa"
+    - dns_zonenodes_matchIP: "/^2a02/"
     - dns_zonenodes_nodeurl: "https://harvester.ffh.zone/nodes.json"
 
     - postfix_myhostname: "mail.ffh.zone"


### PR DESCRIPTION
This is a first commit which switches the n.ffh.zone adresses to public 2a02: addresses. 

Further discussion is still needed, see #35. 

It seems to work quite nicely:
http://alfeld-marktplatz-2.n.ffh.zone/
http://alfeld-bahnhof-1.n.ffh.zone/